### PR TITLE
Fix a warning that relates Faraday's middleware

### DIFF
--- a/lib/rdmm/client.rb
+++ b/lib/rdmm/client.rb
@@ -22,8 +22,8 @@ module Rdmm
     # @return [Faraday::Connection]
     def connection
       @connection ||= ::Faraday::Connection.new(url: BASE_URL) do |connection|
-        connection.adapter :net_http
         connection.response :json
+        connection.adapter :net_http
       end
     end
 


### PR DESCRIPTION
# Summary

A warning has occurred when I use request with rdmm.

e.g.

```
SITE = 'DMM'
KEYWORD = 'xxx'

client = Rdmm::Client.new(affiliate_id: ENV['DMM_AFFILIATE_ID'], api_id: ENV['DMM_API_ID'])
client.list_items(site: SITE, keyword: KEYWORD)
```

## A warning detail

```
WARNING: Unexpected middleware set after the adapter. This won't be supported from Faraday 1.0.
```

## Environment information

- Ruby: `ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]`
- rdmm: `0.2.1`
- faraday: `0.15.2`
- faraday_middleware: `0.12.2`